### PR TITLE
Fixed path to Scs.dll binary in sample and performance test projects.

### DIFF
--- a/performance-tests/Messaging/ClientApp/ClientApp.csproj
+++ b/performance-tests/Messaging/ClientApp/ClientApp.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/performance-tests/Messaging/CommonLib/CommonLib.csproj
+++ b/performance-tests/Messaging/CommonLib/CommonLib.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/performance-tests/Messaging/ServerApp/ServerApp.csproj
+++ b/performance-tests/Messaging/ServerApp/ServerApp.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/performance-tests/RMI/CalculatorClient/CalculatorClient.csproj
+++ b/performance-tests/RMI/CalculatorClient/CalculatorClient.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/performance-tests/RMI/CalculatorCommonLib/CalculatorCommonLib.csproj
+++ b/performance-tests/RMI/CalculatorCommonLib/CalculatorCommonLib.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/performance-tests/RMI/CalculatorServer/CalculatorServer.csproj
+++ b/performance-tests/RMI/CalculatorServer/CalculatorServer.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/CustomWireProtocol/ClientApp/ClientApp.csproj
+++ b/samples/CustomWireProtocol/ClientApp/ClientApp.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/CustomWireProtocol/CommonLib/CommonLib.csproj
+++ b/samples/CustomWireProtocol/CommonLib/CommonLib.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/CustomWireProtocol/ServerApp/ServerApp.csproj
+++ b/samples/CustomWireProtocol/ServerApp/ServerApp.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/IrcChatSystem/ChatClientApp/ChatClientApp.csproj
+++ b/samples/IrcChatSystem/ChatClientApp/ChatClientApp.csproj
@@ -44,7 +44,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/samples/IrcChatSystem/ChatCommonLib/ChatCommonLib.csproj
+++ b/samples/IrcChatSystem/ChatCommonLib/ChatCommonLib.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/IrcChatSystem/ChatServerApp/ChatServerApp.csproj
+++ b/samples/IrcChatSystem/ChatServerApp/ChatServerApp.csproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/samples/OnlinePhoneBook/PhoneBookClient/PhoneBookClient.csproj
+++ b/samples/OnlinePhoneBook/PhoneBookClient/PhoneBookClient.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/OnlinePhoneBook/PhoneBookCommonLib/PhoneBookCommonLib.csproj
+++ b/samples/OnlinePhoneBook/PhoneBookCommonLib/PhoneBookCommonLib.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/OnlinePhoneBook/PhoneBookServer/PhoneBookServer.csproj
+++ b/samples/OnlinePhoneBook/PhoneBookServer/PhoneBookServer.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/OnlinePhoneBook/SimlifiedPhoneBookClient/SimlifiedPhoneBookClient.csproj
+++ b/samples/OnlinePhoneBook/SimlifiedPhoneBookClient/SimlifiedPhoneBookClient.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Scs">
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/SimpleCalculatorSystem/CalculatorClient/CalculatorClient.csproj
+++ b/samples/SimpleCalculatorSystem/CalculatorClient/CalculatorClient.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/SimpleCalculatorSystem/CalculatorCommonLib/CalculatorCommonLib.csproj
+++ b/samples/SimpleCalculatorSystem/CalculatorCommonLib/CalculatorCommonLib.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/SimpleCalculatorSystem/CalculatorServer/CalculatorServer.csproj
+++ b/samples/SimpleCalculatorSystem/CalculatorServer/CalculatorServer.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/SimpleMessaging/ClientApp/ClientApp.csproj
+++ b/samples/SimpleMessaging/ClientApp/ClientApp.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/SimpleMessaging/RequestReplyStyleClient/RequestReplyStyleClient.csproj
+++ b/samples/SimpleMessaging/RequestReplyStyleClient/RequestReplyStyleClient.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/SimpleMessaging/ServerApp/ServerApp.csproj
+++ b/samples/SimpleMessaging/ServerApp/ServerApp.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Scs, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/SimpleMessaging/SynchronizedClient/SynchronizedClient.csproj
+++ b/samples/SimpleMessaging/SynchronizedClient/SynchronizedClient.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Scs">
-      <HintPath>..\..\..\Scs-Binaries\Scs.dll</HintPath>
+      <HintPath>..\..\..\Binaries\Scs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Small fix to get the samples compiling.
