### PR TITLE
Enable or disable the ping timer.

### DIFF
--- a/src/Scs/Communication/Scs/Client/ScsClientBase.cs
+++ b/src/Scs/Communication/Scs/Client/ScsClientBase.cs
@@ -178,6 +178,20 @@ namespace Hik.Communication.Scs.Client
             Disconnect();
         }
 
+      /// <summary>
+      /// Enable  / disable the pingtimer
+      /// </summary>
+        public bool PingTimer
+        {
+          set
+          {
+            if (value)
+              _pingTimer.Start();
+            else
+              _pingTimer.Stop();
+          }
+        }
+
         /// <summary>
         /// Sends a message to the server.
         /// </summary>


### PR DESCRIPTION
For RAW message transport the ping timer causes problems when not connected to an SCS server.