### PR TITLE
Write all exceptions to System.Diagnostics.Trace 

### DIFF
--- a/src/Scs/Communication/Scs/Client/ClientReConnecter.cs
+++ b/src/Scs/Communication/Scs/Client/ClientReConnecter.cs
@@ -100,9 +100,10 @@ namespace Hik.Communication.Scs.Client
                 _client.Connect();
                 _reconnectTimer.Stop();
             }
-            catch
+            catch (Exception exception)
             {
                 //No need to catch since it will try to re-connect again
+                System.Diagnostics.Trace.Write($"ReconnectTimer_Elapsed: {exception}");
             }
         }
     }

--- a/src/Scs/Communication/Scs/Client/ScsClientBase.cs
+++ b/src/Scs/Communication/Scs/Client/ScsClientBase.cs
@@ -267,7 +267,7 @@ namespace Hik.Communication.Scs.Client
             }
             catch (Exception exception)
             {
-                System.Diagnostics.Trace.WriteLine($"PingTimer_Elapsed: {exception}");
+                System.Diagnostics.Trace.Write($"PingTimer_Elapsed: {exception}");
             }
         }
 

--- a/src/Scs/Communication/Scs/Client/ScsClientBase.cs
+++ b/src/Scs/Communication/Scs/Client/ScsClientBase.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Hik.Communication.Scs.Communication;
-using Hik.Communication.Scs.Communication.Messages;
 using Hik.Communication.Scs.Communication.Channels;
+using Hik.Communication.Scs.Communication.Messages;
 using Hik.Communication.Scs.Communication.Protocols;
 using Hik.Threading;
 
@@ -122,7 +122,7 @@ namespace Hik.Communication.Scs.Client
         private readonly Timer _pingTimer;
 
         #endregion
-        
+
         #region Constructor
 
         /// <summary>
@@ -265,9 +265,9 @@ namespace Hik.Communication.Scs.Client
 
                 _communicationChannel.SendMessage(new ScsPingMessage());
             }
-            catch
+            catch (Exception exception)
             {
-
+                System.Diagnostics.Trace.WriteLine($"PingTimer_Elapsed: {exception}");
             }
         }
 

--- a/src/Scs/Communication/Scs/Communication/Channels/Tcp/TcpConnectionListener.cs
+++ b/src/Scs/Communication/Scs/Communication/Channels/Tcp/TcpConnectionListener.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Sockets;
+﻿using System;
+using System.Net.Sockets;
 using System.Threading;
 using Hik.Communication.Scs.Communication.EndPoints.Tcp;
 
@@ -77,9 +78,9 @@ namespace Hik.Communication.Scs.Communication.Channels.Tcp
             {
                 _listenerSocket.Stop();
             }
-            catch
+            catch (Exception exception)
             {
-
+                System.Diagnostics.Trace.Write($"StopSocket: {exception}");
             }
         }
 
@@ -113,9 +114,9 @@ namespace Hik.Communication.Scs.Communication.Channels.Tcp
                     {
                         StartSocket();
                     }
-                    catch
+                    catch (Exception exception)
                     {
-
+                        System.Diagnostics.Trace.Write($"DoListenAsThread: {exception}");
                     }
                 }
             }

--- a/src/Scs/Communication/Scs/Communication/Protocols/BinarySerialization/BinarySerializationProtocol.cs
+++ b/src/Scs/Communication/Scs/Communication/Protocols/BinarySerialization/BinarySerializationProtocol.cs
@@ -60,8 +60,8 @@ namespace Hik.Communication.Scs.Communication.Protocols.BinarySerialization
         public byte[] GetBytes(IScsMessage message)
         {
             //Serialize the message to a byte array
-            var serializedMessage = SerializeMessage(message); 
-           
+            var serializedMessage = SerializeMessage(message);
+
             //Check for message length
             var messageLength = serializedMessage.Length;
             if (messageLength > MaxMessageLength)
@@ -155,16 +155,23 @@ namespace Hik.Communication.Scs.Communication.Protocols.BinarySerialization
             {
                 //Go to head of the stream
                 deserializeMemoryStream.Position = 0;
-                
+
                 //Deserialize the message
                 var binaryFormatter = new BinaryFormatter
                 {
                     AssemblyFormat = System.Runtime.Serialization.Formatters.FormatterAssemblyStyle.Simple,
                     Binder = new DeserializationAppDomainBinder()
                 };
-                
-                //Return the deserialized message
-                return (IScsMessage) binaryFormatter.Deserialize(deserializeMemoryStream);
+
+                try
+                {
+                    //Return the deserialized message
+                    return (IScsMessage)binaryFormatter.Deserialize(deserializeMemoryStream);
+                }
+                catch (Exception exception)
+                {
+                    throw new SerializationException("error while deserializing message", exception);
+                }
             }
         }
 
@@ -233,7 +240,7 @@ namespace Hik.Communication.Scs.Communication.Protocols.BinarySerialization
             //Re-create the receive memory stream and write remaining bytes
             _receiveMemoryStream = new MemoryStream();
             _receiveMemoryStream.Write(remainingBytes, 0, remainingBytes.Length);
-            
+
             //Return true to re-call this method to try to read next message
             return (remainingBytes.Length > 4);
         }

--- a/src/Scs/Communication/ScsServices/Client/ScsServiceClient.cs
+++ b/src/Scs/Communication/ScsServices/Client/ScsServiceClient.cs
@@ -165,7 +165,7 @@ namespace Hik.Communication.ScsServices.Client
             }
 
             //Check client object.
-            if(_clientObject == null)
+            if (_clientObject == null)
             {
                 SendInvokeResponse(invokeMessage, null, new ScsRemoteException("Client does not wait for method invocations by server."));
                 return;
@@ -213,12 +213,12 @@ namespace Hik.Communication.ScsServices.Client
                         RemoteException = exception
                     });
             }
-            catch
+            catch (Exception ex)
             {
-
+                System.Diagnostics.Trace.Write($"SendInvokeResponse: {ex}");
             }
         }
-        
+
         /// <summary>
         /// Handles Connected event of _client object.
         /// </summary>

--- a/src/Scs/Communication/ScsServices/Service/ScsServiceApplication.cs
+++ b/src/Scs/Communication/ScsServices/Service/ScsServiceApplication.cs
@@ -20,7 +20,7 @@ namespace Hik.Communication.ScsServices.Service
         /// This event is raised when a new client connected to the service.
         /// </summary>
         public event EventHandler<ServiceClientEventArgs> ClientConnected;
-       
+
         /// <summary>
         /// This event is raised when a client disconnected from the service.
         /// </summary>
@@ -101,7 +101,7 @@ namespace Hik.Communication.ScsServices.Service
         /// <param name="service">An instance of TServiceClass.</param>
         /// <exception cref="ArgumentNullException">Throws ArgumentNullException if service argument is null</exception>
         /// <exception cref="Exception">Throws Exception if service is already added before</exception>
-        public void AddService<TServiceInterface, TServiceClass>(TServiceClass service) 
+        public void AddService<TServiceInterface, TServiceClass>(TServiceClass service)
             where TServiceClass : ScsService, TServiceInterface
             where TServiceInterface : class
         {
@@ -111,9 +111,9 @@ namespace Hik.Communication.ScsServices.Service
             }
 
             var type = typeof(TServiceInterface);
-            if(_serviceObjects[type.Name] != null)
+            if (_serviceObjects[type.Name] != null)
             {
-                throw new Exception("Service '" + type.Name + "' is already added before.");                
+                throw new Exception("Service '" + type.Name + "' is already added before.");
             }
 
             _serviceObjects[type.Name] = new ServiceObject(type, service);
@@ -177,7 +177,7 @@ namespace Hik.Communication.ScsServices.Service
         private void Client_MessageReceived(object sender, MessageEventArgs e)
         {
             //Get RequestReplyMessenger object (sender of event) to get client
-            var requestReplyMessenger = (RequestReplyMessenger<IScsServerClient>) sender;
+            var requestReplyMessenger = (RequestReplyMessenger<IScsServerClient>)sender;
 
             //Cast message to ScsRemoteInvokeMessage and check it
             var invokeMessage = e.Message as ScsRemoteInvokeMessage;
@@ -256,15 +256,15 @@ namespace Hik.Communication.ScsServices.Service
             {
                 client.SendMessage(
                     new ScsRemoteInvokeReturnMessage
-                        {
-                            RepliedMessageId = requestMessage.MessageId,
-                            ReturnValue = returnValue,
-                            RemoteException = exception
-                        });
+                    {
+                        RepliedMessageId = requestMessage.MessageId,
+                        ReturnValue = returnValue,
+                        RemoteException = exception
+                    });
             }
-            catch
+            catch (Exception ex)
             {
-
+                System.Diagnostics.Trace.Write($"SendInvokeResponse: {ex}");
             }
         }
 

--- a/src/Scs/Threading/SequentialItemProcessor.cs
+++ b/src/Scs/Threading/SequentialItemProcessor.cs
@@ -116,9 +116,9 @@ namespace Hik.Threading
             {
                 _currentProcessTask.Wait();
             }
-            catch
+            catch (Exception exception)
             {
-
+                System.Diagnostics.Trace.Write($"Stop: {exception}");
             }
         }
 


### PR DESCRIPTION
Write all exceptions to System.Diagnostics.Trace  so the erros can be redirected to a log file with a TraceListener
- Handle errors during message deserialization and avoid disconnect - reconnect cycle