### PR TITLE
reset the received memory stream before SerializationException

### DIFF
--- a/src/Scs/Communication/Scs/Communication/Protocols/BinarySerialization/BinarySerializationProtocol.cs
+++ b/src/Scs/Communication/Scs/Communication/Protocols/BinarySerialization/BinarySerializationProtocol.cs
@@ -170,6 +170,7 @@ namespace Hik.Communication.Scs.Communication.Protocols.BinarySerialization
                 }
                 catch (Exception exception)
                 {
+                    Reset(); // reset the received memory stream before the exception is rethrown - otherwise the same erroneous message is received again and again
                     throw new SerializationException("error while deserializing message", exception);
                 }
             }
@@ -232,6 +233,7 @@ namespace Hik.Communication.Scs.Communication.Protocols.BinarySerialization
 
             //Read bytes of serialized message and deserialize it
             var serializedMessageBytes = ReadByteArray(_receiveMemoryStream, messageLength);
+
             messages.Add(DeserializeMessage(serializedMessageBytes));
 
             //Read remaining bytes to an array


### PR DESCRIPTION
Just found out that the received memory stream has to be reset before throwing the SerializationException when the message deserializing went wrong. Otherwise no new messages can be received.

Thanks